### PR TITLE
Add trim commands along with low level PB API

### DIFF
--- a/src/machi.proto
+++ b/src/machi.proto
@@ -48,9 +48,10 @@ enum Mpb_GeneralStatusCode {
      PARTITION = 4;
      NOT_WRITTEN = 5;
      WRITTEN = 6;
-     NO_SUCH_FILE = 7;
-     PARTIAL_READ = 8;
-     BAD_EPOCH = 9;
+     TRIMMED = 7;
+     NO_SUCH_FILE = 8;
+     PARTIAL_READ = 9;
+     BAD_EPOCH = 10;
      BAD_JOSS = 255;    // Only for testing by the Taipan
 }
 
@@ -352,6 +353,7 @@ message Mpb_ProjectionV1 {
 // append_chunk()
 // write_chunk()
 // read_chunk()
+// trim_chunk()
 // checksum_list()
 // list_files()
 // wedge_status()
@@ -422,6 +424,20 @@ message Mpb_LL_ReadChunkResp {
     required Mpb_GeneralStatusCode status = 1;
     optional bytes chunk = 2;
     optional Mpb_ChunkCSum csum = 3;
+}
+
+// Low level API: trim_chunk()
+
+message Mpb_LL_TrimChunkReq {
+    required Mpb_EpochID epoch_id = 1;
+    required string file = 2;
+    required uint64 offset = 3;
+    required uint32 size = 4;
+    optional uint32 trigger_gc = 5 [default=1];
+}
+
+message Mpb_LL_TrimChunkResp {
+    required Mpb_GeneralStatusCode status = 1;
 }
 
 // Low level API: checksum_list()
@@ -588,11 +604,12 @@ message Mpb_LL_Request {
     optional Mpb_LL_AppendChunkReq append_chunk = 30;
     optional Mpb_LL_WriteChunkReq write_chunk = 31;
     optional Mpb_LL_ReadChunkReq read_chunk = 32;
-    optional Mpb_LL_ChecksumListReq checksum_list = 33;
-    optional Mpb_LL_ListFilesReq list_files = 34;
-    optional Mpb_LL_WedgeStatusReq wedge_status = 35;
-    optional Mpb_LL_DeleteMigrationReq delete_migration = 36;
-    optional Mpb_LL_TruncHackReq trunc_hack = 37;
+    optional Mpb_LL_TrimChunkReq trim_chunk = 33;
+    optional Mpb_LL_ChecksumListReq checksum_list = 34;
+    optional Mpb_LL_ListFilesReq list_files = 35;
+    optional Mpb_LL_WedgeStatusReq wedge_status = 36;
+    optional Mpb_LL_DeleteMigrationReq delete_migration = 37;
+    optional Mpb_LL_TruncHackReq trunc_hack = 38;
 }
 
 message Mpb_LL_Response {
@@ -622,9 +639,10 @@ message Mpb_LL_Response {
     optional Mpb_LL_AppendChunkResp append_chunk = 30;
     optional Mpb_LL_WriteChunkResp write_chunk = 31;
     optional Mpb_LL_ReadChunkResp read_chunk = 32;
-    optional Mpb_LL_ChecksumListResp checksum_list = 33;
-    optional Mpb_LL_ListFilesResp list_files = 34;
-    optional Mpb_LL_WedgeStatusResp wedge_status = 35;
-    optional Mpb_LL_DeleteMigrationResp delete_migration = 36;
-    optional Mpb_LL_TruncHackResp trunc_hack = 37;
+    optional Mpb_LL_TrimChunkResp trim_chunk = 33;
+    optional Mpb_LL_ChecksumListResp checksum_list = 34;
+    optional Mpb_LL_ListFilesResp list_files = 35;
+    optional Mpb_LL_WedgeStatusResp wedge_status = 36;
+    optional Mpb_LL_DeleteMigrationResp delete_migration = 37;
+    optional Mpb_LL_TruncHackResp trunc_hack = 38;
 }

--- a/src/machi_cr_client.erl
+++ b/src/machi_cr_client.erl
@@ -548,7 +548,9 @@ do_read_chunk2(File, Offset, Size, Depth, STime, TO,
             read_repair(ConsistencyMode, read, File, Offset, Size, Depth, STime, S);
             %% {reply, {error, not_written}, S};
         {error, written} ->
-            exit({todo_should_never_happen,?MODULE,?LINE,File,Offset,Size})
+            exit({todo_should_never_happen,?MODULE,?LINE,File,Offset,Size});
+        {error, trimmed}=Err ->
+            {reply, Err, S}
     end.
 
 do_trim_chunk(File, Offset, Size, 0=Depth, STime, TO, S) ->
@@ -592,9 +594,7 @@ do_trim_chunk2(File, Offset, Size, Depth, STime, TO,
           when Retry == partition; Retry == bad_epoch; Retry == wedged ->
             do_trim_chunk(File, Offset, Size, Depth, STime, TO, S);
         {error, trimmed} ->
-            {reply, ok, S};
-        {error, bad_joss_taipan_fixme} ->
-            {reply, {error, bad_joss}, S}
+            {reply, ok, S}
     end.
 
 do_trim_midtail(RestFLUs, Prefix, File, Offset, Size,

--- a/src/machi_cr_client.erl
+++ b/src/machi_cr_client.erl
@@ -551,9 +551,116 @@ do_read_chunk2(File, Offset, Size, Depth, STime, TO,
             exit({todo_should_never_happen,?MODULE,?LINE,File,Offset,Size})
     end.
 
-do_trim_chunk(_File, _Offset, _Size, _Depth, _STime, _TO, S) ->
-    %% This is just a stub to reach CR client from high level client
-    {reply, {error, bad_joss}, S}.
+do_trim_chunk(File, Offset, Size, 0=Depth, STime, TO, S) ->
+    do_trim_chunk(File, Offset, Size, Depth+1, STime, TO, S);
+    
+do_trim_chunk(File, Offset, Size, Depth, STime, TO, #state{proj=P}=S) ->
+    sleep_a_while(Depth),
+    DiffMs = timer:now_diff(os:timestamp(), STime) div 1000,
+    if DiffMs > TO ->
+            {reply, {error, partition}, S};
+       true ->
+            %% This is suboptimal for performance: there are some paths
+            %% through this point where our current projection is good
+            %% enough.  But we're going to try to keep the code as simple
+            %% as we can for now.
+            S2 = update_proj(S#state{proj=undefined, bad_proj=P}),
+            case S2#state.proj of
+                P2 when P2 == undefined orelse
+                        P2#projection_v1.upi == [] ->
+                    do_trim_chunk(File, Offset, Size, Depth + 1,
+                                  STime, TO, S2);
+                _ ->
+                    do_trim_chunk2(File, Offset, Size, Depth + 1,
+                                   STime, TO, S2)
+            end
+    end.
+
+do_trim_chunk2(File, Offset, Size, Depth, STime, TO,
+               #state{epoch_id=EpochID, proj=P, proxies_dict=PD}=S) ->
+    [HeadFLU|RestFLUs] = mutation_flus(P),
+    Proxy = orddict:fetch(HeadFLU, PD),
+    case ?FLU_PC:trim_chunk(Proxy, EpochID, File, Offset, Size, ?TIMEOUT) of
+        ok ->
+            %% From this point onward, we use the same code & logic path as
+            %% append does.
+            do_trim_midtail(RestFLUs, undefined, File, Offset, Size,
+                            [HeadFLU], 0, STime, TO, S);
+        {error, bad_checksum}=BadCS ->
+            {reply, BadCS, S};
+        {error, Retry}
+          when Retry == partition; Retry == bad_epoch; Retry == wedged ->
+            do_trim_chunk(File, Offset, Size, Depth, STime, TO, S);
+        {error, trimmed} ->
+            {reply, ok, S};
+        {error, bad_joss_taipan_fixme} ->
+            {reply, {error, bad_joss}, S}
+    end.
+
+do_trim_midtail(RestFLUs, Prefix, File, Offset, Size,
+                Ws, Depth, STime, TO, S)
+  when RestFLUs == [] orelse Depth == 0 ->
+       do_trim_midtail2(RestFLUs, Prefix, File, Offset, Size,
+                        Ws, Depth + 1, STime, TO, S);
+do_trim_midtail(_RestFLUs, Prefix, File, Offset, Size,
+                Ws, Depth, STime, TO, #state{proj=P}=S) ->
+    %% io:format(user, "midtail sleep2,", []),
+    sleep_a_while(Depth),
+    DiffMs = timer:now_diff(os:timestamp(), STime) div 1000,
+    if DiffMs > TO ->
+            {reply, {error, partition}, S};
+       true ->
+            S2 = update_proj(S#state{proj=undefined, bad_proj=P}),
+            case S2#state.proj of
+                undefined ->
+                    {reply, {error, partition}, S};
+                P2 ->
+                    RestFLUs2 = mutation_flus(P2),
+                    case RestFLUs2 -- Ws of
+                        RestFLUs2 ->
+                            %% None of the writes that we have done so far
+                            %% are to FLUs that are in the RestFLUs2 list.
+                            %% We are pessimistic here and assume that
+                            %% those FLUs are permanently dead.  Start
+                            %% over with a new sequencer assignment, at
+                            %% the 2nd have of the impl (we have already
+                            %% slept & refreshed the projection).
+
+                            if Prefix == undefined -> % atom! not binary()!!
+                                    {error, partition};
+                               true ->
+                                    do_trim_chunk(Prefix, Offset, Size,
+                                                  Depth, STime, TO, S2)
+                            end;
+                        RestFLUs3 ->
+                            do_trim_midtail2(RestFLUs3, Prefix, File, Offset, Size,
+                                             Ws, Depth + 1, STime, TO, S2)
+                    end
+            end
+    end.            
+
+do_trim_midtail2([], _Prefix, _File, _Offset, _Size,
+                   _Ws, _Depth, _STime, _TO, S) ->
+    %% io:format(user, "ok!\n", []),
+    {reply, ok, S};
+do_trim_midtail2([FLU|RestFLUs]=FLUs, Prefix, File, Offset, Size,
+                   Ws, Depth, STime, TO,
+                   #state{epoch_id=EpochID, proxies_dict=PD}=S) ->
+    Proxy = orddict:fetch(FLU, PD),
+    case ?FLU_PC:trim_chunk(Proxy, EpochID, File, Offset, Size, ?TIMEOUT) of
+        ok ->
+            %% io:format(user, "write ~w,", [FLU]),
+            do_trim_midtail2(RestFLUs, Prefix, File, Offset, Size,
+                             [FLU|Ws], Depth, STime, TO, S);
+        {error, bad_checksum}=BadCS ->
+            %% TODO: alternate strategy?
+            {reply, BadCS, S};
+        {error, Retry}
+          when Retry == partition; Retry == bad_epoch; Retry == wedged ->
+            do_trim_midtail(FLUs, Prefix, File, Offset, Size,
+                            Ws, Depth, STime, TO, S)
+    end.
+
 
 %% Read repair: depends on the consistency mode that we're in:
 %%

--- a/src/machi_flu1.erl
+++ b/src/machi_flu1.erl
@@ -391,6 +391,9 @@ do_pb_ll_request3({low_write_chunk, _EpochID, File, Offset, Chunk, CSum_tag,
 do_pb_ll_request3({low_read_chunk, _EpochID, File, Offset, Size, Opts},
                   #state{witness=false}=S) ->
     {do_server_read_chunk(File, Offset, Size, Opts, S), S};
+do_pb_ll_request3({low_trim_chunk, _EpochID, File, Offset, Size, TriggerGC},
+                  #state{witness=false}=S) ->
+    {do_server_trim_chunk(File, Offset, Size, TriggerGC, S), S};
 do_pb_ll_request3({low_checksum_list, _EpochID, File},
                   #state{witness=false}=S) ->
     {do_server_checksum_listing(File, S), S};
@@ -544,7 +547,12 @@ do_server_read_chunk(File, Offset, Size, _Opts, #state{flu_name=FluName})->
             {error, bad_arg}
     end.
 
-do_server_checksum_listing(File, #state{flu_name=FluName, data_dir=DataDir}=_S) ->
+do_server_trim_chunk(File, Offset, Size, TriggerGC, _S) ->
+    io:format(user, "Hi there! I'm trimming this: ~s, (~p, ~p), ~p~n",
+              [File, Offset, Size, TriggerGC]),
+    {error, bad_joss}.
+
+do_server_checksum_listing(File, #state{data_dir=DataDir}=_S) ->
     case sanitize_file_string(File) of
         ok ->
             ok = sync_checksum_file(FluName, File),

--- a/src/machi_flu1.erl
+++ b/src/machi_flu1.erl
@@ -74,6 +74,7 @@
           epoch_id        :: 'undefined' | machi_dt:epoch_id(),
           pb_mode = undefined  :: 'undefined' | 'high' | 'low',
           high_clnt       :: 'undefined' | pid(),
+          trim_table      :: ets:tid(),
           props = []      :: list()  % proplist
          }).
 
@@ -129,6 +130,7 @@ main2(FluName, TcpPort, DataDir, Props) ->
                 {true, undefined}
         end,
     Witness_p = proplists:get_value(witness_mode, Props, false),
+    
     S0 = #state{flu_name=FluName,
                 proj_store=ProjectionPid,
                 tcp_port=TcpPort,
@@ -148,7 +150,26 @@ main2(FluName, TcpPort, DataDir, Props) ->
        true ->
             ok
     end,
-    S1 = S0#state{append_pid=AppendPid},
+
+    %% TODO: on trimming, flu server is going to keep a table of
+    %% trimmed chunks. Although the original data is written in
+    %% checksum file, but it's too big to read and parse at each read
+    %% request. So hereby it should be recovered here before starting
+    %% any external service. All such live data is kept in trim_table.
+    %%
+    %% Q. How large checksum file could be? Does it pay to open and
+    %%    to cache by reading through every time flu server started over?
+    %%
+    %% 1. get all existing checksum files
+    %% 2. read through and find all trim entries, ignoring all checksums
+    %% But it's still TODO, just leave as it's empty
+    TrimTableName = list_to_atom(lists:flatten(["machi_flu1_trim_table_", 
+                                                atom_to_list(FluName)])),
+    TrimTable = ets:new(TrimTableName, [public, bag, named_table,
+                                        {read_concurrency, true}]),
+
+    S1 = S0#state{append_pid=AppendPid, trim_table=TrimTable},
+
     ListenPid = start_listen_server(S1),
 
     Config_e = machi_util:make_config_filename(DataDir, "unused"),
@@ -389,7 +410,7 @@ do_pb_ll_request3({low_write_chunk, _EpochID, File, Offset, Chunk, CSum_tag,
                   #state{witness=false}=S) ->
     {do_server_write_chunk(File, Offset, Chunk, CSum_tag, CSum, S), S};
 do_pb_ll_request3({low_read_chunk, _EpochID, File, Offset, Size, Opts},
-                  #state{witness=false}=S) ->
+                  #state{witness=false} = S) ->
     {do_server_read_chunk(File, Offset, Size, Opts, S), S};
 do_pb_ll_request3({low_trim_chunk, _EpochID, File, Offset, Size, TriggerGC},
                   #state{witness=false}=S) ->
@@ -547,12 +568,18 @@ do_server_read_chunk(File, Offset, Size, _Opts, #state{flu_name=FluName})->
             {error, bad_arg}
     end.
 
-do_server_trim_chunk(File, Offset, Size, TriggerGC, _S) ->
+do_server_trim_chunk(File, Offset, Size, TriggerGC, #state{flu_name=FluName}) ->
     io:format(user, "Hi there! I'm trimming this: ~s, (~p, ~p), ~p~n",
               [File, Offset, Size, TriggerGC]),
-    {error, bad_joss}.
+    case sanitize_file_string(File) of
+        ok ->
+            {ok, Pid} = machi_flu_metadata_mgr:start_proxy_pid(FluName, {file, File}),
+            machi_file_proxy:trim(Pid, Offset, Size, TriggerGC);
+        _ ->
+            {error, bad_arg}
+    end.
 
-do_server_checksum_listing(File, #state{data_dir=DataDir}=_S) ->
+do_server_checksum_listing(File, #state{flu_name=FluName, data_dir=DataDir}=_S) ->
     case sanitize_file_string(File) of
         ok ->
             ok = sync_checksum_file(FluName, File),

--- a/src/machi_pb_high_client.erl
+++ b/src/machi_pb_high_client.erl
@@ -401,6 +401,8 @@ convert_general_status_code('NOT_WRITTEN') ->
     {error, not_written};
 convert_general_status_code('WRITTEN') ->
     {error, written};
+convert_general_status_code('TRIMMED') ->
+    {error, trimmed};
 convert_general_status_code('NO_SUCH_FILE') ->
     {error, no_such_file};
 convert_general_status_code('PARTIAL_READ') ->

--- a/src/machi_pb_translate.erl
+++ b/src/machi_pb_translate.erl
@@ -896,6 +896,8 @@ conv_from_status({error, not_written}) ->
     'NOT_WRITTEN';
 conv_from_status({error, written}) ->
     'WRITTEN';
+conv_from_status({error, trimmed}) ->
+    'TRIMMED';
 conv_from_status({error, no_such_file}) ->
     'NO_SUCH_FILE';
 conv_from_status({error, partial_read}) ->

--- a/src/machi_pb_translate.erl
+++ b/src/machi_pb_translate.erl
@@ -84,6 +84,17 @@ from_pb_request(#mpb_ll_request{
     {ReqID, {low_read_chunk, EpochID, File, Offset, Size, Opts}};
 from_pb_request(#mpb_ll_request{
                    req_id=ReqID,
+                   trim_chunk=#mpb_ll_trimchunkreq{
+                     epoch_id=PB_EpochID,
+                     file=File,
+                     offset=Offset,
+                     size=Size,
+                                 trigger_gc=PB_TriggerGC}}) ->
+    EpochID = conv_to_epoch_id(PB_EpochID),
+    TriggerGC = conv_to_boolean(PB_TriggerGC),
+    {ReqID, {low_trim_chunk, EpochID, File, Offset, Size, TriggerGC}};
+from_pb_request(#mpb_ll_request{
+                   req_id=ReqID,
                    checksum_list=#mpb_ll_checksumlistreq{
                      epoch_id=PB_EpochID,
                      file=File}}) ->
@@ -238,6 +249,10 @@ from_pb_response(#mpb_ll_response{
     end;
 from_pb_response(#mpb_ll_response{
                     req_id=ReqID,
+                    trim_chunk=#mpb_ll_trimchunkresp{status=Status}}) ->
+    {ReqID, machi_pb_high_client:convert_general_status_code(Status)};
+from_pb_response(#mpb_ll_response{
+                    req_id=ReqID,
                     checksum_list=#mpb_ll_checksumlistresp{
                       status=Status, chunk=Chunk}}) ->
     case Status of
@@ -381,6 +396,15 @@ to_pb_request(ReqID, {low_read_chunk, EpochID, File, Offset, Size, _Opts}) ->
                  file=File,
                  offset=Offset,
                  size=Size}};
+to_pb_request(ReqID, {low_trim_chunk, EpochID, File, Offset, Size, TriggerGC}) ->
+    PB_EpochID = conv_from_epoch_id(EpochID),
+    #mpb_ll_request{req_id=ReqID, do_not_alter=2,
+                    trim_chunk=#mpb_ll_trimchunkreq{
+                                  epoch_id=PB_EpochID,
+                                  file=File,
+                                  offset=Offset,
+                                  size=Size,
+                                  trigger_gc=TriggerGC}};
 to_pb_request(ReqID, {low_checksum_list, EpochID, File}) ->
     PB_EpochID = conv_from_epoch_id(EpochID),
     #mpb_ll_request{req_id=ReqID, do_not_alter=2,
@@ -476,6 +500,18 @@ to_pb_response(ReqID, {low_read_chunk, _EID, _Fl, _Off, _Sz, _Opts}, Resp)->
             Status = conv_from_status(Error),
             #mpb_ll_response{req_id=ReqID,
                              read_chunk=#mpb_ll_readchunkresp{status=Status}};
+        _Else ->
+            make_ll_error_resp(ReqID, 66, io_lib:format("err ~p", [_Else]))
+    end;
+to_pb_response(ReqID, {low_trim_chunk, _, _, _, _, _}, Resp) ->
+    case Resp of
+        ok ->
+            #mpb_ll_response{req_id=ReqID,
+                             trim_chunk=#mpb_ll_trimchunkresp{status='OK'}};
+        {error, _}=Error ->
+            Status = conv_from_status(Error),
+            #mpb_ll_response{req_id=ReqID,
+                             read_chunk=#mpb_ll_trimchunkresp{status=Status}};
         _Else ->
             make_ll_error_resp(ReqID, 66, io_lib:format("err ~p", [_Else]))
     end;

--- a/src/machi_proxy_flu1_client.erl
+++ b/src/machi_proxy_flu1_client.erl
@@ -79,6 +79,7 @@
 
          %% Internal API
          write_chunk/5, write_chunk/6,
+         trim_chunk/5, trim_chunk/6,
 
          %% Helpers
          stop_proxies/1, start_proxies/1
@@ -310,6 +311,18 @@ write_chunk(PidSpec, EpochID, File, Offset, Chunk, Timeout) ->
             Else
     end.
 
+
+trim_chunk(PidSpec, EpochID, File, Offset, Size) ->
+    trim_chunk(PidSpec, EpochID, File, Offset, Size, infinity).
+
+%% @doc Write a chunk (binary- or iolist-style) of data to a file
+%% with `Prefix' at `Offset'.
+
+trim_chunk(PidSpec, EpochID, File, Offset, Chunk, Timeout) ->
+    gen_server:call(PidSpec,
+                    {req, {trim_chunk, EpochID, File, Offset, Chunk}},
+                    Timeout).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 init([I]) ->
@@ -383,6 +396,9 @@ make_req_fun({read_chunk, EpochID, File, Offset, Size},
 make_req_fun({write_chunk, EpochID, File, Offset, Chunk},
              #state{sock=Sock,i=#p_srvr{proto_mod=Mod}}) ->
     fun() -> Mod:write_chunk(Sock, EpochID, File, Offset, Chunk) end;
+make_req_fun({trim_chunk, EpochID, File, Offset, Size},
+             #state{sock=Sock,i=#p_srvr{proto_mod=Mod}}) ->
+    fun() -> Mod:trim_chunk(Sock, EpochID, File, Offset, Size) end;
 make_req_fun({checksum_list, EpochID, File},
              #state{sock=Sock,i=#p_srvr{proto_mod=Mod}}) ->
     fun() -> Mod:checksum_list(Sock, EpochID, File) end;

--- a/test/machi_pb_high_client_test.erl
+++ b/test/machi_pb_high_client_test.erl
@@ -89,16 +89,14 @@ smoke_test2() ->
             true = is_integer(File1Size),
 
             [begin
-                 %% ok = ?C:trim_chunk(Clnt, Fl, Off, Sz)
-                 %% This gets an error as trim API is still a stub
-                 ?assertMatch({bummer,
-                               {throw,
-                                {error, bad_joss_taipan_fixme},
-                                _Boring_stack_trace}},
-                              ?C:trim_chunk(Clnt, Fl, Off, Sz))
+                 ok = ?C:trim_chunk(Clnt, Fl, Off, Sz)
+             end || {Ch, Fl, Off, Sz} <- Reads],
+            [begin
+                 io:format(user, "~p~n", [{Fl, Off, Sz}]),
+                 {error, trimmed} = ?C:read_chunk(Clnt, Fl, Off, Sz),
+                 io:format(user, "~p~n", [{Fl, Off, Sz}])
              end || {Ch, Fl, Off, Sz} <- Reads],
             ?debugVal(?C:list_files(Clnt)),
-
             ok
         after
             (catch ?C:quit(Clnt))


### PR DESCRIPTION
Follows #11 . This pull request includes:
- Low level PB protocol definitions and their implementations at FLU server
- Introduces a change at 
- Actual trim command that leaves a trim mark checksum file

A `read_chunk()` will return `{error, trimmed}` if that chunk is trimmed. If a arbitrary read request that does not match trim-table, the flu server returns raw data in the file without checking whether it's trimmed or not. But that will be done in the next-next-(^10) pull request.
