### PR TITLE
Allow reading multiple chunks at once

### DIFF
--- a/src/machi_file_proxy.erl
+++ b/src/machi_file_proxy.erl
@@ -127,7 +127,7 @@ sync(_Pid, Type) ->
 
 % @doc Read file at offset for length. This returns a sequence of all
 % chunks that overlaps with requested offset and length. Note that
-% borders are not alinged, not to mess up repair at cr_client with
+% borders are not aligned, not to mess up repair at cr_client with
 % checksums. They should be cut at cr_client.
 -spec read(Pid :: pid(),
            Offset :: non_neg_integer(),

--- a/src/machi_pb_translate.erl
+++ b/src/machi_pb_translate.erl
@@ -659,7 +659,6 @@ to_pb_response(ReqID, {high_read_chunk, _File, _Offset, _Size}, Resp) ->
         {ok, Chunks} ->
             MpbChunks = lists:map(fun({File, Offset, Bytes, Csum}) ->
                                           {Tag, Ck} = machi_util:unmake_tagged_csum(Csum),
-                                          io:format(user, "~p oom~n", [Csum]),
                                           #mpb_chunk{
                                              offset=Offset,
                                              file_name=File,

--- a/test/machi_cr_client_test.erl
+++ b/test/machi_cr_client_test.erl
@@ -149,8 +149,10 @@ smoke_test2() ->
         %% Misc API smoke & minor regression checks
         {error, bad_arg} = machi_cr_client:read_chunk(C1, <<"no">>,
                                                           999999999, 1),
-        {error, not_written} = machi_cr_client:read_chunk(C1, File1,
-                                                           Off1, 88888888),
+        {ok, [{_,Off1,Chunk1,_},
+              {_,FooOff1,Chunk1,_},
+              {_,FooOff2,Chunk2,_}]} = machi_cr_client:read_chunk(C1, File1,
+                                              Off1, 88888888),
         %% Checksum list return value is a primitive binary().
         {ok, KludgeBin} = machi_cr_client:checksum_list(C1, File1),
         true = is_binary(KludgeBin),

--- a/test/machi_csum_table_test.erl
+++ b/test/machi_csum_table_test.erl
@@ -1,16 +1,21 @@
 -module(machi_csum_table_test).
 -compile(export_all).
 
+-include_lib("eunit/include/eunit.hrl").
+-define(HDR, {0, 1024, <<0>>}).
+
 smoke_test() ->
     Filename = "./temp-checksum-dumb-file",
     _ = file:delete(Filename),
     {ok, MC} = machi_csum_table:open(Filename, []),
-    {Offset, Size, Checksum} = {64, 34, <<"deadbeef">>},
-    {error, unknown_chunk} = machi_csum_table:find(MC, Offset, Size),
+    [{1024, infinity}] = machi_csum_table:calc_unwritten_bytes(MC),
+    Entry = {Offset, Size, Checksum} = {1064, 34, <<"deadbeef">>},
+    [] = machi_csum_table:find(MC, Offset, Size),
     ok = machi_csum_table:write(MC, Offset, Size, Checksum),
-    {ok, Checksum} = machi_csum_table:find(MC, Offset, Size),
+    [{1024, 40}, {1098, infinity}] = machi_csum_table:calc_unwritten_bytes(MC),
+    [Entry] = machi_csum_table:find(MC, Offset, Size),
     ok = machi_csum_table:trim(MC, Offset, Size),
-    {error, trimmed} = machi_csum_table:find(MC, Offset, Size),
+    [{Offset, Size, trimmed}] = machi_csum_table:find(MC, Offset, Size),
     ok = machi_csum_table:close(MC),
     ok = machi_csum_table:delete(MC).
 
@@ -18,14 +23,35 @@ close_test() ->
     Filename = "./temp-checksum-dumb-file-2",
     _ = file:delete(Filename),
     {ok, MC} = machi_csum_table:open(Filename, []),
-    {Offset, Size, Checksum} = {64, 34, <<"deadbeef">>},
-    {error, unknown_chunk} = machi_csum_table:find(MC, Offset, Size),
+    Entry = {Offset, Size, Checksum} = {1064, 34, <<"deadbeef">>},
+    [] = machi_csum_table:find(MC, Offset, Size),
     ok = machi_csum_table:write(MC, Offset, Size, Checksum),
-    {ok, Checksum} = machi_csum_table:find(MC, Offset, Size),
+    [Entry] = machi_csum_table:find(MC, Offset, Size),
     ok = machi_csum_table:close(MC),
 
     {ok, MC2} = machi_csum_table:open(Filename, []),
-    {ok, Checksum} = machi_csum_table:find(MC2, Offset, Size),
+    [Entry] = machi_csum_table:find(MC2, Offset, Size),
     ok = machi_csum_table:trim(MC2, Offset, Size),
-    {error, trimmed} = machi_csum_table:find(MC2, Offset, Size),
+    [{Offset, Size, trimmed}] = machi_csum_table:find(MC2, Offset, Size),
     ok = machi_csum_table:delete(MC2).
+
+smoke2_test() ->
+    Filename = "./temp-checksum-dumb-file-3",
+    _ = file:delete(Filename),
+    {ok, MC} = machi_csum_table:open(Filename, []),
+    Entry = {Offset, Size, Checksum} = {1025, 10, <<"deadbeef">>},
+    ok = machi_csum_table:write(MC, Offset, Size, Checksum),
+    [] = machi_csum_table:find(MC, 0, 0),
+    [?HDR] = machi_csum_table:find(MC, 0, 1),
+    [Entry] = machi_csum_table:find(MC, Offset, Size),
+    [?HDR] = machi_csum_table:find(MC, 1, 1024),
+    [?HDR, Entry] = machi_csum_table:find(MC, 1023, 1024),
+    [Entry] = machi_csum_table:find(MC, 1024, 1024),
+    [Entry] = machi_csum_table:find(MC, 1025, 1024),
+
+    ok = machi_csum_table:trim(MC, Offset, Size),
+    [{Offset, Size, trimmed}] = machi_csum_table:find(MC, Offset, Size),
+    ok = machi_csum_table:close(MC),
+    ok = machi_csum_table:delete(MC).
+
+%% TODO: add quickcheck test here

--- a/test/machi_file_proxy_eqc.erl
+++ b/test/machi_file_proxy_eqc.erl
@@ -203,7 +203,7 @@ read_next(S, _Res, _Args) -> S.
 read(Pid, Offset, Length) ->
     case machi_file_proxy:read(Pid, Offset, Length) of
         {ok, Chunks} ->
-            [{_, Offset, Data, Csum}] = machi_cr_client:trim_both_side(Chunks, Offset, Length),
+            [{_, Offset, Data, Csum}] = machi_cr_client:trim_both_side(Chunks, Offset, Offset+Length),
             {ok, Data, Csum};
         E ->
             E

--- a/test/machi_file_proxy_eqc.erl
+++ b/test/machi_file_proxy_eqc.erl
@@ -202,7 +202,8 @@ read_next(S, _Res, _Args) -> S.
 
 read(Pid, Offset, Length) ->
     case machi_file_proxy:read(Pid, Offset, Length) of
-        {ok, [{_, Offset, Data, Csum}]} ->
+        {ok, Chunks} ->
+            [{_, Offset, Data, Csum}] = machi_cr_client:trim_both_side(Chunks, Offset, Length),
             {ok, Data, Csum};
         E ->
             E


### PR DESCRIPTION
- When repairing multiple chunks at once and any of its repair
  failed, the whole read request and repair work will fail
- Rename read_repair3 and read_repair4 to do_repair_chunks and
  do_repair chunk in machi_file_proxy
- This pull request changes return semantics of read_chunk(), that
  returns any chunk included in requested range
- First and last chunk may be cut to fit the requested range
- In machi_file_proxy, unwritten_bytes are removed and replaced by
  machi_csum_table
