### PR TITLE
Update read_chunk() PB protocol to return trimmed chunks

### DIFF
--- a/src/machi.proto
+++ b/src/machi.proto
@@ -205,11 +205,15 @@ message Mpb_ReadChunkReq {
     // only makes sense if flag_no_checksum is not set).
     // TODO: not implemented yet.
     optional uint32 flag_no_chunk = 3 [default=0];
+
+    // TODO: not implemented yet.
+    optional uint32 flag_needs_trimmed = 4 [default=0];
 }
 
 message Mpb_ReadChunkResp {
     required Mpb_GeneralStatusCode status = 1;
     repeated Mpb_Chunk chunks = 2;
+    repeated Mpb_ChunkPos trimmed = 3;
 }
 
 // High level API: trim_chunk() request & response
@@ -410,11 +414,14 @@ message Mpb_LL_ReadChunkReq {
     // only makes sense if flag_checksum is not set).
     // TODO: not implemented yet.
     optional uint32 flag_no_chunk = 4 [default=0];
+
+    optional uint32 flag_needs_trimmed = 5 [default=0];
 }
 
 message Mpb_LL_ReadChunkResp {
     required Mpb_GeneralStatusCode status = 1;
     repeated Mpb_Chunk chunks = 2;
+    repeated Mpb_ChunkPos trimmed = 3;
 }
 
 // Low level API: checksum_list()

--- a/src/machi_admin_util.erl
+++ b/src/machi_admin_util.erl
@@ -76,7 +76,7 @@ verify_file_checksums_local2(Sock1, EpochID, Path0) ->
                 ReadChunk = fun(F, Offset, Size) ->
                                     case file:pread(FH, Offset, Size) of
                                         {ok, Bin} ->
-                                            {ok, [{F, Offset, Bin, undefined}]};
+                                            {ok, {[{F, Offset, Bin, undefined}], []}};
                                         Err ->
                                             Err
                                     end
@@ -92,7 +92,7 @@ verify_file_checksums_local2(Sock1, EpochID, Path0) ->
 verify_file_checksums_remote2(Sock1, EpochID, File) ->
     ReadChunk = fun(File_name, Offset, Size) ->
                         ?FLU_C:read_chunk(Sock1, EpochID,
-                                          File_name, Offset, Size)
+                                          File_name, Offset, Size, [])
                 end,
     verify_file_checksums_common(Sock1, EpochID, File, ReadChunk).
 
@@ -117,7 +117,7 @@ verify_file_checksums_common(Sock1, EpochID, File, ReadChunk) ->
 verify_chunk_checksum(File, ReadChunk) ->
     fun({Offset, Size, <<_Tag:1/binary, CSum/binary>>}, Acc) ->
             case ReadChunk(File, Offset, Size) of
-                {ok, [{_, Offset, Chunk, _}]} ->
+                {ok, {[{_, Offset, Chunk, _}], _}} ->
                     CSum2 = machi_util:checksum_chunk(Chunk),
                     if CSum == CSum2 ->
                             Acc;

--- a/src/machi_chain_repair.erl
+++ b/src/machi_chain_repair.erl
@@ -324,7 +324,8 @@ execute_repair_directive({File, Cmds}, {ProxiesDict, EpochID, Verb, ETS}=Acc) ->
                     _ -> ok
                 end,
                 _T1 = os:timestamp(),
-                {ok, [{_, Offset, Chunk, _}]} =
+                %% TODO: support case multiple written or trimmed chunks returned
+                {ok, {[{_, Offset, Chunk, _}], _}} =
                     machi_proxy_flu1_client:read_chunk(
                       SrcP, EpochID, File, Offset, Size,
                       ?SHORT_TIMEOUT),

--- a/src/machi_flu1.erl
+++ b/src/machi_flu1.erl
@@ -450,9 +450,9 @@ do_pb_hl_request2({high_write_chunk, File, Offset, ChunkBin, TaggedCSum},
     Chunk = {TaggedCSum, ChunkBin},
     Res = machi_cr_client:write_chunk(Clnt, File, Offset, Chunk),
     {Res, S};
-do_pb_hl_request2({high_read_chunk, File, Offset, Size},
+do_pb_hl_request2({high_read_chunk, File, Offset, Size, Opts},
                   #state{high_clnt=Clnt}=S) ->
-    Res = machi_cr_client:read_chunk(Clnt, File, Offset, Size),
+    Res = machi_cr_client:read_chunk(Clnt, File, Offset, Size, Opts),
     {Res, S};
 do_pb_hl_request2({high_trim_chunk, File, Offset, Size},
                   #state{high_clnt=Clnt}=S) ->
@@ -548,13 +548,13 @@ do_server_write_chunk(File, Offset, Chunk, CSum_tag, CSum, #state{flu_name=FluNa
             {error, bad_arg}
     end.
 
-do_server_read_chunk(File, Offset, Size, _Opts, #state{flu_name=FluName})->
+do_server_read_chunk(File, Offset, Size, Opts, #state{flu_name=FluName})->
     %% TODO: Look inside Opts someday.
     case sanitize_file_string(File) of
         ok ->
             {ok, Pid} = machi_flu_metadata_mgr:start_proxy_pid(FluName, {file, File}),
-            case machi_file_proxy:read(Pid, Offset, Size) of
-                {ok, Chunks} -> {ok, Chunks};
+            case machi_file_proxy:read(Pid, Offset, Size, Opts) of
+                {ok, ChunksAndTrimmed} -> {ok, ChunksAndTrimmed};
                 Other -> Other
             end;
         _ ->

--- a/src/machi_util.erl
+++ b/src/machi_util.erl
@@ -47,7 +47,9 @@
          combinations/1, ordered_combinations/1,
          mk_order/2,
          %% Other
-         wait_for_death/2, wait_for_life/2
+         wait_for_death/2, wait_for_life/2,
+         bool2int/1,
+         int2bool/1
         ]).
 
 -include("machi.hrl").
@@ -390,3 +392,9 @@ mk_order(UPI2, Repair1) ->
                       error     -> error
                   end || X <- UPI2],
     UPI2_order.
+
+%% C-style conversion for PB usage.
+bool2int(true) -> 1;
+bool2int(false) -> 0.
+int2bool(0) -> false;
+int2bool(I) when is_integer(I) -> true.

--- a/test/machi_file_proxy_eqc.erl
+++ b/test/machi_file_proxy_eqc.erl
@@ -202,8 +202,9 @@ read_next(S, _Res, _Args) -> S.
 
 read(Pid, Offset, Length) ->
     case machi_file_proxy:read(Pid, Offset, Length) of
-        {ok, Chunks} ->
-            [{_, Offset, Data, Csum}] = machi_cr_client:trim_both_side(Chunks, Offset, Offset+Length),
+        {ok, {Chunks, _}} ->
+            [{_, Offset, Data, Csum}] =
+                machi_cr_client:trim_both_side(Chunks, Offset, Offset+Length),
             {ok, Data, Csum};
         E ->
             E

--- a/test/machi_file_proxy_test.erl
+++ b/test/machi_file_proxy_test.erl
@@ -80,22 +80,22 @@ machi_file_proxy_test_() ->
     clean_up_data_dir(?TESTDIR),
     {ok, Pid} = machi_file_proxy:start_link("test", ?TESTDIR),
     [
-	?_assertEqual({error, bad_arg}, machi_file_proxy:read(Pid, -1, -1)),
-	?_assertEqual({error, bad_arg}, machi_file_proxy:write(Pid, -1, <<"yo">>)),
-	?_assertEqual({error, bad_arg}, machi_file_proxy:append(Pid, [], -1, <<"krep">>)),
-	?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1, 1)),
-        ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1024, 1)),
-        ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1, 1024)),
-        ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1024, ?HYOOGE)),
-        ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, ?HYOOGE, 1)),
-	?_assertEqual({error, written}, machi_file_proxy:write(Pid, 1, random_binary(0, ?HYOOGE))),
-	?_assertMatch({ok, "test", _}, machi_file_proxy:append(Pid, random_binary(0, 1024))),
-	?_assertEqual({error, written}, machi_file_proxy:write(Pid, 1024, <<"fail">>)),
-	?_assertEqual({error, written}, machi_file_proxy:write(Pid, 1, <<"fail">>)),
-	?_assertMatch({ok, [{_, _, _, _}]}, machi_file_proxy:read(Pid, 1025, 1000)),
-	?_assertMatch({ok, "test", _}, machi_file_proxy:append(Pid, [], 1024, <<"mind the gap">>)),
-	?_assertEqual(ok, machi_file_proxy:write(Pid, 2060, [], random_binary(0, 1024))),
-        ?_assertException(exit, {normal, _}, machi_file_proxy:stop(Pid))
+     ?_assertEqual({error, bad_arg}, machi_file_proxy:read(Pid, -1, -1)),
+     ?_assertEqual({error, bad_arg}, machi_file_proxy:write(Pid, -1, <<"yo">>)),
+     ?_assertEqual({error, bad_arg}, machi_file_proxy:append(Pid, [], -1, <<"krep">>)),
+     ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1, 1)),
+     ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1024, 1)),
+     ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1, 1024)),
+     ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, 1024, ?HYOOGE)),
+     ?_assertEqual({error, not_written}, machi_file_proxy:read(Pid, ?HYOOGE, 1)),
+     ?_assertEqual({error, written}, machi_file_proxy:write(Pid, 1, random_binary(0, ?HYOOGE))),
+     ?_assertMatch({ok, "test", _}, machi_file_proxy:append(Pid, random_binary(0, 1024))),
+     ?_assertEqual({error, written}, machi_file_proxy:write(Pid, 1024, <<"fail">>)),
+     ?_assertEqual({error, written}, machi_file_proxy:write(Pid, 1, <<"fail">>)),
+     ?_assertMatch({ok, {[{_, _, _, _}], []}}, machi_file_proxy:read(Pid, 1025, 1000)),
+     ?_assertMatch({ok, "test", _}, machi_file_proxy:append(Pid, [], 1024, <<"mind the gap">>)),
+     ?_assertEqual(ok, machi_file_proxy:write(Pid, 2060, [], random_binary(0, 1024))),
+     ?_assertException(exit, {normal, _}, machi_file_proxy:stop(Pid))
     ].
 
 multiple_chunks_read_test_() ->
@@ -108,11 +108,11 @@ multiple_chunks_read_test_() ->
      ?_assertEqual(ok, machi_file_proxy:write(Pid, 30000, <<"fail">>)),
      %% Freeza
      ?_assertEqual(ok, machi_file_proxy:write(Pid, 530000, <<"fail">>)),
-     ?_assertMatch({ok, [{"test", 1024, _, _},
-                         {"test", 10000, <<"fail">>, _},
-                         {"test", 20000, <<"fail">>, _},
-                         {"test", 30000, <<"fail">>, _},
-                         {"test", 530000, <<"fail">>, _}]},
+     ?_assertMatch({ok, {[{"test", 1024, _, _},
+                          {"test", 10000, <<"fail">>, _},
+                          {"test", 20000, <<"fail">>, _},
+                          {"test", 30000, <<"fail">>, _},
+                          {"test", 530000, <<"fail">>, _}], []}},
                    machi_file_proxy:read(Pid, 1024, 530000)),
      ?_assertException(exit, {normal, _}, machi_file_proxy:stop(Pid))
     ].

--- a/test/machi_flu1_test.erl
+++ b/test/machi_flu1_test.erl
@@ -97,8 +97,8 @@ flu_smoke_test() ->
         {ok, {Off1,Len1,File1}} = ?FLU_C:append_chunk(Host, TcpPort,
                                                       ?DUMMY_PV1_EPOCH,
                                                       Prefix, Chunk1),
-        {ok, [{_, Off1, Chunk1, _}]} = ?FLU_C:read_chunk(Host, TcpPort, ?DUMMY_PV1_EPOCH,
-                                                         File1, Off1, Len1),
+        {ok, {[{_, Off1, Chunk1, _}], _}} = ?FLU_C:read_chunk(Host, TcpPort, ?DUMMY_PV1_EPOCH,
+                                                         File1, Off1, Len1, []),
         {ok, KludgeBin} = ?FLU_C:checksum_list(Host, TcpPort,
                                                ?DUMMY_PV1_EPOCH, File1),
         true = is_binary(KludgeBin),
@@ -109,7 +109,7 @@ flu_smoke_test() ->
         Len1 = size(Chunk1),
         {error, not_written} = ?FLU_C:read_chunk(Host, TcpPort,
                                                   ?DUMMY_PV1_EPOCH,
-                                                  File1, Off1*983829323, Len1),
+                                                  File1, Off1*983829323, Len1, []),
         %% XXX FIXME
         %%
         %% This is failing because the read extends past the end of the file.
@@ -151,14 +151,14 @@ flu_smoke_test() ->
                                 File2, Off2, Chunk2),
         {error, bad_arg} = ?FLU_C:write_chunk(Host, TcpPort, ?DUMMY_PV1_EPOCH,
                                               BadFile, Off2, Chunk2),
-        {ok, [{_, Off2, Chunk2, _}]} = ?FLU_C:read_chunk(Host, TcpPort, ?DUMMY_PV1_EPOCH,
-                                         File2, Off2, Len2),
+        {ok, {[{_, Off2, Chunk2, _}], _}} =
+            ?FLU_C:read_chunk(Host, TcpPort, ?DUMMY_PV1_EPOCH, File2, Off2, Len2, []),
         {error, bad_arg} = ?FLU_C:read_chunk(Host, TcpPort,
                                                  ?DUMMY_PV1_EPOCH,
-                                                 "no!!", Off2, Len2),
+                                                 "no!!", Off2, Len2, []),
         {error, bad_arg} = ?FLU_C:read_chunk(Host, TcpPort,
                                              ?DUMMY_PV1_EPOCH,
-                                             BadFile, Off2, Len2),
+                                             BadFile, Off2, Len2, []),
 
         %% We know that File1 still exists.  Pretend that we've done a
         %% migration and exercise the delete_migration() API.
@@ -261,7 +261,7 @@ witness_test() ->
                                                Prefix, Chunk1),
         File = <<"foofile">>,
         {error, bad_arg} = ?FLU_C:read_chunk(Host, TcpPort, EpochID1,
-                                             File, 9999, 9999),
+                                             File, 9999, 9999, []),
         {error, bad_arg} = ?FLU_C:checksum_list(Host, TcpPort, EpochID1,
                                                 File),
         {error, bad_arg} = ?FLU_C:list_files(Host, TcpPort, EpochID1),

--- a/test/machi_flu_psup_test.erl
+++ b/test/machi_flu_psup_test.erl
@@ -146,7 +146,7 @@ partial_stop_restart2() ->
         {_, #p_srvr{address=Addr_a, port=TcpPort_a}} = hd(Ps),
         {error, wedged} = machi_flu1_client:read_chunk(
                             Addr_a, TcpPort_a, ?DUMMY_PV1_EPOCH,
-                            <<>>, 99999999, 1),
+                            <<>>, 99999999, 1, []),
         {error, wedged} = machi_flu1_client:checksum_list(
                             Addr_a, TcpPort_a, ?DUMMY_PV1_EPOCH, <<>>),
         %% list_files() is permitted despite wedged status

--- a/test/machi_pb_high_client_test.erl
+++ b/test/machi_pb_high_client_test.erl
@@ -81,8 +81,8 @@ smoke_test2() ->
                      {iolist_to_binary(Chunk3), File3, Off3, Size3}],
             [begin
                  File = binary_to_list(Fl),
-                 ?assertMatch({ok, [{File, Off, Ch, _}]},
-                              ?C:read_chunk(Clnt, Fl, Off, Sz))
+                 ?assertMatch({ok, {[{File, Off, Ch, _}], []}},
+                              ?C:read_chunk(Clnt, Fl, Off, Sz, []))
              end || {Ch, Fl, Off, Sz} <- Reads],
 
             {ok, KludgeBin} = ?C:checksum_list(Clnt, File1),

--- a/test/machi_proxy_flu1_client_test.erl
+++ b/test/machi_proxy_flu1_client_test.erl
@@ -60,14 +60,14 @@ api_smoke_test() ->
             {ok, {MyOff,MySize,MyFile}} =
                 ?MUT:append_chunk(Prox1, FakeEpoch, Prefix, MyChunk,
                                   infinity),
-            {ok, [{_, MyOff, MyChunk, _}]} =
-                ?MUT:read_chunk(Prox1, FakeEpoch, MyFile, MyOff, MySize),
+            {ok, {[{_, MyOff, MyChunk, _}], []}} =
+                ?MUT:read_chunk(Prox1, FakeEpoch, MyFile, MyOff, MySize, []),
             MyChunk2 = <<"my chunk data, yeah, again">>,
             {ok, {MyOff2,MySize2,MyFile2}} =
                 ?MUT:append_chunk_extra(Prox1, FakeEpoch, Prefix,
                                         MyChunk2, 4242, infinity),
-            {ok, [{_, MyOff2, MyChunk2, _}]} =
-                ?MUT:read_chunk(Prox1, FakeEpoch, MyFile2, MyOff2, MySize2),
+            {ok, {[{_, MyOff2, MyChunk2, _}], []}} =
+                ?MUT:read_chunk(Prox1, FakeEpoch, MyFile2, MyOff2, MySize2, []),
             MyChunk_badcs = {<<?CSUM_TAG_CLIENT_SHA:8, 0:(8*20)>>, MyChunk},
             {error, bad_checksum} = ?MUT:append_chunk(Prox1, FakeEpoch,
                                                       Prefix, MyChunk_badcs),
@@ -245,13 +245,13 @@ flu_restart_test2() ->
                     (stop) -> ?MUT:append_chunk_extra(Prox1, FakeEpoch,
                                              <<"prefix">>, Data, 42, infinity)
                  end,
-                 fun(run) -> {ok, [{_, Off1, Data, _}]} =
+                 fun(run) -> {ok, {[{_, Off1, Data, _}], []}} =
                                  ?MUT:read_chunk(Prox1, FakeEpoch,
-                                                 File1, Off1, Size1),
+                                                 File1, Off1, Size1, []),
                              ok;
                     (line) -> io:format("line ~p, ", [?LINE]);
                     (stop) -> ?MUT:read_chunk(Prox1, FakeEpoch,
-                                                 File1, Off1, Size1)
+                                              File1, Off1, Size1, [])
                  end,
                  fun(run) -> {ok, KludgeBin} =
                                  ?MUT:checksum_list(Prox1, FakeEpoch, File1),


### PR DESCRIPTION
- Add `trimed` array of chunk_pos at read_chunk message
- `trimmed` are only filled only when `needs_trimmed` is true which is false by default
- Pass options defined in PB protocol to the flu server
- several minor changes in repair code (like change from `spawn` to `spawn_link`)

Will follow with actual trim implementation later.
