### PR TITLE
Introduce config system and first example

### DIFF
--- a/include/machi.hrl
+++ b/include/machi.hrl
@@ -18,10 +18,9 @@
 %%
 %% -------------------------------------------------------------------
 
--define(MAX_FILE_SIZE, 256*1024*1024).     % 256 MBytes
--define(MAX_CHUNK_SIZE, ((1 bsl 32) - 1)).
-%% -define(DATA_DIR, "/Volumes/SAM1/seq-tests/data").
--define(DATA_DIR, "./data").
+%% @doc Now 4GiBytes, could be up to 64bit due to PB message limit of
+%% chunk size
+-define(DEFAULT_MAX_FILE_SIZE, ((1 bsl 32) - 1)).
 -define(MINIMUM_OFFSET, 1024).
 
 %% 0th draft of checksum typing with 1st byte.
@@ -34,4 +33,5 @@
 -define(PB_MAX_MSG_SIZE, (33*1024*1024)).
 -define(PB_PACKET_OPTS, [{packet, 4}, {packet_size, ?PB_MAX_MSG_SIZE}]).
 
+%% TODO: it's used in flu_sup and elsewhere, change this to suitable name
 -define(TEST_ETS_TABLE, test_ets_table).

--- a/priv/test-for-gh-pr.sh
+++ b/priv/test-for-gh-pr.sh
@@ -4,6 +4,7 @@ if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 	echo '$TRAVIS_PULL_REQUEST is false, skipping tests'
 	exit 0
 else
-	echo '$TRAVIS_PULL_REQUEST is not false, running tests'
+	echo '$TRAVIS_PULL_REQUEST is not false ($TRAVIS_PULL_REQUEST), running tests'
 	make test
+	make dialyzer
 fi

--- a/src/machi.app.src
+++ b/src/machi.app.src
@@ -5,6 +5,6 @@
     {mod,{machi_app,[]}},
     {registered, []},
     {env, [
-    %% Don't use this env for defaults, or I'll give some poopies
+    %% Don't use this static env for defaults, or we will fall into config hell.
     ]}
 ]}.

--- a/src/machi.app.src
+++ b/src/machi.app.src
@@ -5,9 +5,6 @@
     {mod,{machi_app,[]}},
     {registered, []},
     {env, [
-           {flu_list,
-            [
-             %%%%%% {flu_a, 32900, "./data.flu_a"}
-            ]}
+    %% Don't use this env for defaults, or I'll give some poopies
     ]}
 ]}.

--- a/src/machi_config.erl
+++ b/src/machi_config.erl
@@ -1,0 +1,43 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Configuration consulting utilities. Some conventions:
+%% - The function name should match with exact configuration
+%%   name in `app.config' or `advanced.config' of `machi' section.
+%% - The default value of that configuration is expected to be in
+%%   cuttlefish schema file. Otherwise some macro in headers may
+%%   be chosen.
+%% - Documentation of the configuration is supposed to be written
+%%   in cuttlefish schema file, rather than @doc section of the function.
+%% - spec of the function should be written.
+%% - Returning `undefined' is strongly discouraged. Return some default
+%%   value instead.
+%% - `application:get_env/3' is recommended. See `max_file_size/0' for
+%%   example.
+
+-module(machi_config).
+
+-include("machi.hrl").
+
+-export([max_file_size/0]).
+
+-spec max_file_size() -> pos_integer().
+max_file_size() ->
+    application:get_env(machi, max_file_size, ?MAX_FILE_SIZE).

--- a/src/machi_config.erl
+++ b/src/machi_config.erl
@@ -40,4 +40,4 @@
 
 -spec max_file_size() -> pos_integer().
 max_file_size() ->
-    application:get_env(machi, max_file_size, ?MAX_FILE_SIZE).
+    application:get_env(machi, max_file_size, ?DEFAULT_MAX_FILE_SIZE).

--- a/src/machi_file_proxy.erl
+++ b/src/machi_file_proxy.erl
@@ -86,8 +86,8 @@
     csum_path             :: string()|undefined,
     data_filehandle       :: file:io_device(),
     csum_table            :: machi_csum_table:table(),
-    eof_position = 0      :: machi_dt:chunk_pos(),
-    max_file_size = ?DEFAULT_MAX_FILE_SIZE :: machi_dt:chunk_pos(),
+    eof_position = 0      :: non_neg_integer(),
+    max_file_size = ?DEFAULT_MAX_FILE_SIZE :: pos_integer(),
     tref                  :: reference(), %% timer ref
     ticks = 0             :: non_neg_integer(), %% ticks elapsed with no new operations
     ops = 0               :: non_neg_integer(), %% sum of all ops

--- a/src/machi_file_proxy.erl
+++ b/src/machi_file_proxy.erl
@@ -283,7 +283,6 @@ handle_call({read, Offset, Length, Opts}, _From,
             State = #state{filename = F,
                            data_filehandle = FH,
                            csum_table = CsumTable,
-                           eof_position = EofP,
                            reads = {T, Err}
                           }) ->
     NoChecksum = proplists:get_value(no_checksum, Opts, false),
@@ -317,7 +316,6 @@ handle_call({write, Offset, ClientMeta, Data}, _From,
             State = #state{filename = F,
                            writes = {T, Err},
                            data_filehandle = FHd,
-                           eof_position=EofP,
                            csum_table = CsumTable}) ->
 
     ClientCsumTag = proplists:get_value(client_csum_tag, ClientMeta, ?CSUM_TAG_NONE),


### PR DESCRIPTION
As we'll introduce many tunable knobs in future, I introduced `machi_config.erl` to gather all knobs at single file. Don't use .app.src for application environment. I would love to have header comments in `machi_config.erl` reviewed, which is a guideline to introduce new config item.
