### PR TITLE
Trim command and GC prototype implementation

### DIFF
--- a/src/machi.proto
+++ b/src/machi.proto
@@ -48,9 +48,10 @@ enum Mpb_GeneralStatusCode {
      PARTITION = 4;
      NOT_WRITTEN = 5;
      WRITTEN = 6;
-     NO_SUCH_FILE = 7;
-     PARTIAL_READ = 8;
-     BAD_EPOCH = 9;
+     TRIMMED = 7; // The whole file was trimmed
+     NO_SUCH_FILE = 8;
+     PARTIAL_READ = 9;
+     BAD_EPOCH = 10;
      BAD_JOSS = 255;    // Only for testing by the Taipan
 }
 
@@ -355,6 +356,7 @@ message Mpb_ProjectionV1 {
 // append_chunk()
 // write_chunk()
 // read_chunk()
+// trim_chunk()
 // checksum_list()
 // list_files()
 // wedge_status()
@@ -422,6 +424,20 @@ message Mpb_LL_ReadChunkResp {
     required Mpb_GeneralStatusCode status = 1;
     repeated Mpb_Chunk chunks = 2;
     repeated Mpb_ChunkPos trimmed = 3;
+}
+
+// Low level API: trim_chunk()
+
+message Mpb_LL_TrimChunkReq {
+    required Mpb_EpochID epoch_id = 1;
+    required string file = 2;
+    required uint64 offset = 3;
+    required uint32 size = 4;
+    optional uint32 trigger_gc = 5 [default=1];
+}
+
+message Mpb_LL_TrimChunkResp {
+    required Mpb_GeneralStatusCode status = 1;
 }
 
 // Low level API: checksum_list()
@@ -588,11 +604,12 @@ message Mpb_LL_Request {
     optional Mpb_LL_AppendChunkReq append_chunk = 30;
     optional Mpb_LL_WriteChunkReq write_chunk = 31;
     optional Mpb_LL_ReadChunkReq read_chunk = 32;
-    optional Mpb_LL_ChecksumListReq checksum_list = 33;
-    optional Mpb_LL_ListFilesReq list_files = 34;
-    optional Mpb_LL_WedgeStatusReq wedge_status = 35;
-    optional Mpb_LL_DeleteMigrationReq delete_migration = 36;
-    optional Mpb_LL_TruncHackReq trunc_hack = 37;
+    optional Mpb_LL_TrimChunkReq trim_chunk = 33;
+    optional Mpb_LL_ChecksumListReq checksum_list = 34;
+    optional Mpb_LL_ListFilesReq list_files = 35;
+    optional Mpb_LL_WedgeStatusReq wedge_status = 36;
+    optional Mpb_LL_DeleteMigrationReq delete_migration = 37;
+    optional Mpb_LL_TruncHackReq trunc_hack = 38;
 }
 
 message Mpb_LL_Response {
@@ -622,9 +639,10 @@ message Mpb_LL_Response {
     optional Mpb_LL_AppendChunkResp append_chunk = 30;
     optional Mpb_LL_WriteChunkResp write_chunk = 31;
     optional Mpb_LL_ReadChunkResp read_chunk = 32;
-    optional Mpb_LL_ChecksumListResp checksum_list = 33;
-    optional Mpb_LL_ListFilesResp list_files = 34;
-    optional Mpb_LL_WedgeStatusResp wedge_status = 35;
-    optional Mpb_LL_DeleteMigrationResp delete_migration = 36;
-    optional Mpb_LL_TruncHackResp trunc_hack = 37;
+    optional Mpb_LL_TrimChunkResp trim_chunk = 33;
+    optional Mpb_LL_ChecksumListResp checksum_list = 34;
+    optional Mpb_LL_ListFilesResp list_files = 35;
+    optional Mpb_LL_WedgeStatusResp wedge_status = 36;
+    optional Mpb_LL_DeleteMigrationResp delete_migration = 37;
+    optional Mpb_LL_TruncHackResp trunc_hack = 38;
 }

--- a/src/machi.proto
+++ b/src/machi.proto
@@ -433,7 +433,7 @@ message Mpb_LL_TrimChunkReq {
     required string file = 2;
     required uint64 offset = 3;
     required uint32 size = 4;
-    optional uint32 trigger_gc = 5 [default=1];
+    optional uint32 trigger_gc = 5 [default=0];
 }
 
 message Mpb_LL_TrimChunkResp {

--- a/src/machi_cr_client.erl
+++ b/src/machi_cr_client.erl
@@ -600,8 +600,6 @@ do_trim_chunk2(File, Offset, Size, Depth, STime, TO,
     Proxy = orddict:fetch(HeadFLU, PD),
     case ?FLU_PC:trim_chunk(Proxy, EpochID, File, Offset, Size, ?TIMEOUT) of
         ok ->
-            %% From this point onward, we use the same code & logic path as
-            %% append does.
             do_trim_midtail(RestFLUs, undefined, File, Offset, Size,
                             [HeadFLU], 0, STime, TO, S);
         {error, trimmed} ->

--- a/src/machi_csum_table.erl
+++ b/src/machi_csum_table.erl
@@ -177,7 +177,14 @@ all_trimmed(#machi_csum_table{table=T}, Left, Right) ->
 
 -spec all_trimmed(table(), machi_dt:chunk_pos()) -> boolean().
 all_trimmed(#machi_csum_table{table=T}, Pos) ->
-    runthru(ets:tab2list(T), 0, Pos).
+    case ets:tab2list(T) of
+        [{0, ?MINIMUM_OFFSET, _}|L] ->
+            %% tl/1 to remove header space {0, 1024, <<0>>}
+            runthru(L, ?MINIMUM_OFFSET, Pos);
+        List ->
+            %% In case a header is removed;
+            runthru(List, 0, Pos)
+    end.
 
 -spec any_trimmed(table(),
                   pos_integer(),

--- a/src/machi_csum_table.erl
+++ b/src/machi_csum_table.erl
@@ -171,11 +171,11 @@ trim(#machi_csum_table{fd=Fd, table=T}, Offset, Size) ->
             Error
     end.
 
--spec all_trimmed(table(), machi_dt:chunk_pos(), machi_dt:chunk_pos()) -> boolean().
+-spec all_trimmed(table(), non_neg_integer(), non_neg_integer()) -> boolean().
 all_trimmed(#machi_csum_table{table=T}, Left, Right) ->
     runthru(ets:tab2list(T), Left, Right).
 
--spec all_trimmed(table(), machi_dt:chunk_pos()) -> boolean().
+-spec all_trimmed(table(), non_neg_integer()) -> boolean().
 all_trimmed(#machi_csum_table{table=T}, Pos) ->
     case ets:tab2list(T) of
         [{0, ?MINIMUM_OFFSET, _}|L] ->

--- a/src/machi_file_proxy_sup.erl
+++ b/src/machi_file_proxy_sup.erl
@@ -44,7 +44,8 @@ start_link(FluName) ->
     supervisor:start_link({local, make_proxy_name(FluName)}, ?MODULE, []).
 
 start_proxy(FluName, DataDir, Filename) ->
-    supervisor:start_child(make_proxy_name(FluName), [Filename, DataDir]).
+    supervisor:start_child(make_proxy_name(FluName),
+                           [FluName, Filename, DataDir]).
 
 init([]) ->
     SupFlags = {simple_one_for_one, 1000, 10},

--- a/src/machi_flu1_client.erl
+++ b/src/machi_flu1_client.erl
@@ -80,6 +80,7 @@
 %% For "internal" replication only.
 -export([
          write_chunk/5, write_chunk/6,
+         trim_chunk/5, trim_chunk/6,
          delete_migration/3, delete_migration/4,
          trunc_hack/3, trunc_hack/4
         ]).
@@ -473,6 +474,31 @@ write_chunk(Host, TcpPort, EpochID, File, Offset, Chunk)
     after
         disconnect(Sock)
     end.
+
+%% @doc Restricted API: Write a chunk of already-sequenced data to
+%% `File' at `Offset'.
+
+-spec trim_chunk(port_wrap(), machi_dt:epoch_id(), machi_dt:file_name(), machi_dt:file_offset(), machi_dt:chunk_size()) ->
+      ok | {error, machi_dt:error_general()} | {error, term()}.
+trim_chunk(Sock, EpochID, File0, Offset, Size)
+  when Offset >= ?MINIMUM_OFFSET ->
+    ReqID = <<"id">>,
+    File = machi_util:make_binary(File0),
+    true = (Offset >= ?MINIMUM_OFFSET),
+    Req = machi_pb_translate:to_pb_request(
+            ReqID,
+            {low_trim_chunk, EpochID, File, Offset, Size, 0}),
+    do_pb_request_common(Sock, ReqID, Req).
+
+%% @doc Restricted API: Write a chunk of already-sequenced data to
+%% `File' at `Offset'.
+
+-spec trim_chunk(machi_dt:inet_host(), machi_dt:inet_port(),
+                  machi_dt:epoch_id(), machi_dt:file_name(), machi_dt:file_offset(), machi_dt:chunk_size()) ->
+      ok | {error, machi_dt:error_general()} | {error, term()}.
+trim_chunk(_Host, _TcpPort, _EpochID, _File, _Offset, _Size) ->
+    not_used.
+
 
 %% @doc Restricted API: Delete a file after it has been successfully
 %% migrated.

--- a/src/machi_flu1_client.erl
+++ b/src/machi_flu1_client.erl
@@ -80,7 +80,7 @@
 %% For "internal" replication only.
 -export([
          write_chunk/5, write_chunk/6,
-         trim_chunk/5, trim_chunk/6,
+         trim_chunk/5,
          delete_migration/3, delete_migration/4,
          trunc_hack/3, trunc_hack/4
         ]).
@@ -489,16 +489,6 @@ trim_chunk(Sock, EpochID, File0, Offset, Size)
             ReqID,
             {low_trim_chunk, EpochID, File, Offset, Size, 0}),
     do_pb_request_common(Sock, ReqID, Req).
-
-%% @doc Restricted API: Write a chunk of already-sequenced data to
-%% `File' at `Offset'.
-
--spec trim_chunk(machi_dt:inet_host(), machi_dt:inet_port(),
-                  machi_dt:epoch_id(), machi_dt:file_name(), machi_dt:file_offset(), machi_dt:chunk_size()) ->
-      ok | {error, machi_dt:error_general()} | {error, term()}.
-trim_chunk(_Host, _TcpPort, _EpochID, _File, _Offset, _Size) ->
-    not_used.
-
 
 %% @doc Restricted API: Delete a file after it has been successfully
 %% migrated.

--- a/src/machi_flu_metadata_mgr.erl
+++ b/src/machi_flu_metadata_mgr.erl
@@ -39,10 +39,13 @@
 -define(HASH(X), erlang:phash2(X)). %% hash algorithm to use
 -define(TIMEOUT, 10 * 1000). %% 10 second timeout
 
+-define(KNOWN_FILES_LIST_PREFIX, "known_files_").
+
 -record(state, {fluname :: atom(),
                 datadir :: string(),
                 tid     :: ets:tid(),
-                cnt     :: non_neg_integer()
+                cnt     :: non_neg_integer(),
+                trimmed_files :: machi_plist:plist()
                }).
 
 %% This record goes in the ets table where filename is the key
@@ -59,7 +62,8 @@
          lookup_proxy_pid/2,
          start_proxy_pid/2,
          stop_proxy_pid/2,
-         build_metadata_mgr_name/2
+         build_metadata_mgr_name/2,
+         trim_file/2
         ]).
 
 %% gen_server callbacks
@@ -97,10 +101,24 @@ start_proxy_pid(FluName, {file, Filename}) ->
 stop_proxy_pid(FluName, {file, Filename}) ->
     gen_server:call(get_manager_atom(FluName, Filename), {stop_proxy_pid, Filename}, ?TIMEOUT).
 
+trim_file(FluName, {file, Filename}) ->
+    gen_server:call(get_manager_atom(FluName, Filename), {trim_file, Filename}, ?TIMEOUT).
+
 %% gen_server callbacks
 init([FluName, Name, DataDir, Num]) ->
+    %% important: we'll need another persistent storage to
+    %% remember deleted (trimmed) file, to prevent resurrection after
+    %% flu restart and append.
+    FileListFileName =
+        filename:join([DataDir, ?KNOWN_FILES_LIST_PREFIX ++ atom_to_list(FluName)]),
+    {ok, PList} = machi_plist:open(FileListFileName, []),
+    %% TODO make sure all files non-existent, if any remaining files
+    %% here, just delete it. They're in the list *because* they're all
+    %% trimmed.
+
     Tid = ets:new(Name, [{keypos, 2}, {read_concurrency, true}, {write_concurrency, true}]),
-    {ok, #state{ fluname = FluName, datadir = DataDir, tid = Tid, cnt = Num}}.
+    {ok, #state{fluname = FluName, datadir = DataDir, tid = Tid, cnt = Num,
+                trimmed_files=PList}}.
 
 handle_cast(Req, State) ->
     lager:warning("Got unknown cast ~p", [Req]),
@@ -113,17 +131,25 @@ handle_call({proxy_pid, Filename}, _From, State = #state{ tid = Tid }) ->
     end,
     {reply, Reply, State};
 
-handle_call({start_proxy_pid, Filename}, _From, State = #state{ fluname = N, tid = Tid, datadir = D }) ->
-    NewR = case lookup_md(Tid, Filename) of
-        not_found ->
-            start_file_proxy(N, D, Filename);
-        #md{ proxy_pid = undefined } = R0 ->
-            start_file_proxy(N, D, R0);
-        #md{ proxy_pid = _Pid } = R1 ->
-            R1
-    end,
-    update_ets(Tid, NewR),
-    {reply, {ok, NewR#md.proxy_pid}, State};
+handle_call({start_proxy_pid, Filename}, _From,
+            State = #state{ fluname = N, tid = Tid, datadir = D,
+                            trimmed_files=TrimmedFiles}) ->
+    case machi_plist:find(TrimmedFiles, Filename) of
+        false ->
+            NewR = case lookup_md(Tid, Filename) of
+                       not_found ->
+                           start_file_proxy(N, D, Filename);
+                       #md{ proxy_pid = undefined } = R0 ->
+                           start_file_proxy(N, D, R0);
+                       #md{ proxy_pid = _Pid } = R1 ->
+                           R1
+                   end,
+            update_ets(Tid, NewR),
+            {reply, {ok, NewR#md.proxy_pid}, State};
+        true ->
+            {reply, {error, trimmed}, State}
+    end;
+
 handle_call({stop_proxy_pid, Filename}, _From, State = #state{ tid = Tid }) ->
     case lookup_md(Tid, Filename) of
         not_found ->
@@ -136,6 +162,15 @@ handle_call({stop_proxy_pid, Filename}, _From, State = #state{ tid = Tid }) ->
             update_ets(Tid, R#md{ proxy_pid = undefined, mref = undefined })
     end,
     {reply, ok, State};
+
+handle_call({trim_file, Filename}, _,
+            S = #state{trimmed_files = TrimmedFiles }) ->
+    case machi_plist:add(TrimmedFiles, Filename) of
+        {ok, TrimmedFiles2} ->
+            {reply, ok, S#state{trimmed_files=TrimmedFiles2}};
+        Error ->
+            {reply, Error, S}
+    end;
 
 handle_call(Req, From, State) ->
     lager:warning("Got unknown call ~p from ~p", [Req, From]),
@@ -169,18 +204,21 @@ handle_info({'DOWN', Mref, process, Pid, wedged}, State = #state{ tid = Tid }) -
     lager:error("file proxy ~p shutdown because it's wedged", [Pid]),
     clear_ets(Tid, Mref),
     {noreply, State};
+handle_info({'DOWN', _Mref, process, Pid, trimmed}, State = #state{ tid = _Tid }) ->
+    lager:debug("file proxy ~p shutdown because the file was trimmed", [Pid]),
+    {noreply, State};
 handle_info({'DOWN', Mref, process, Pid, Error}, State = #state{ tid = Tid }) ->
     lager:error("file proxy ~p shutdown because ~p", [Pid, Error]),
     clear_ets(Tid, Mref),
     {noreply, State};
 
-
 handle_info(Info, State) ->
     lager:warning("Got unknown info ~p", [Info]),
     {noreply, State}.
 
-terminate(Reason, _State) ->
+terminate(Reason, _State = #state{trimmed_files=TrimmedFiles}) ->
     lager:info("Shutting down because ~p", [Reason]),
+    machi_plist:close(TrimmedFiles),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/machi_pb_high_client.erl
+++ b/src/machi_pb_high_client.erl
@@ -94,6 +94,9 @@ write_chunk(PidSpec, File, Offset, Chunk, CSum) ->
 write_chunk(PidSpec, File, Offset, Chunk, CSum, Timeout) ->
     send_sync(PidSpec, {write_chunk, File, Offset, Chunk, CSum}, Timeout).
 
+%% @doc Tries to read a chunk of a specified file. It returns `{ok,
+%% {Chunks, TrimmedChunks}}' for live file while it returns `{error,
+%% trimmed}' if all bytes of the file was trimmed.
 -spec read_chunk(pid(), string(), pos_integer(), pos_integer(),
                  [{flag_no_checksum | flag_no_chunk | needs_trimmed, boolean()}]) ->
                         {ok, {list(), list()}} | {error, term()}.
@@ -107,6 +110,10 @@ read_chunk(PidSpec, File, Offset, Size, Options) ->
 read_chunk(PidSpec, File, Offset, Size, Options, Timeout) ->
     send_sync(PidSpec, {read_chunk, File, Offset, Size, Options}, Timeout).
 
+%% @doc Trims arbitrary binary range of any file. TODO: Add option
+%% specifying whether to trigger GC.
+-spec trim_chunk(pid(), string(), non_neg_integer(), machi_dt:chunk_size()) ->
+                        ok | {error, term()}.
 trim_chunk(PidSpec, File, Offset, Size) ->
     trim_chunk(PidSpec, File, Offset, Size, ?DEFAULT_TIMEOUT).
 
@@ -415,6 +422,8 @@ convert_general_status_code('NOT_WRITTEN') ->
     {error, not_written};
 convert_general_status_code('WRITTEN') ->
     {error, written};
+convert_general_status_code('TRIMMED') ->
+    {error, trimmed};
 convert_general_status_code('NO_SUCH_FILE') ->
     {error, no_such_file};
 convert_general_status_code('PARTIAL_READ') ->

--- a/src/machi_plist.erl
+++ b/src/machi_plist.erl
@@ -1,0 +1,63 @@
+-module(machi_plist).
+
+%%% @doc persistent list of binaries that support mutual exclusion
+
+-export([open/2, close/1, find/2, add/2]).
+
+-ifdef(TEST).
+-export([all/1]).
+-endif.
+
+-record(machi_plist,
+        {filename :: string(),
+         fd :: file:descriptor(),
+        list}).
+
+-type plist() :: #machi_plist{}.
+-export_type([plist/0]).
+
+-spec open(filename:filename(), proplists:proplist()) ->
+                  {ok, plist()} | {error, file:posix()}.
+open(Filename, _Opt) ->
+    List = case file:read_file(Filename) of
+               {ok, <<>>} -> [];
+               {ok, Bin} -> binary_to_term(Bin);
+               {error, enoent} -> []
+           end,
+    case file:open(Filename, [read, write, raw, binary, sync]) of
+        {ok, Fd} ->
+            {ok, #machi_plist{filename=Filename,
+                              fd=Fd,
+                              list=List}};
+        Error ->
+            Error
+    end.
+
+-spec close(plist()) -> ok.
+close(#machi_plist{fd=Fd}) ->
+    _ = file:close(Fd).
+
+-spec find(plist(), string()) -> boolean().
+find(#machi_plist{list=List}, Name) ->
+    lists:member(Name, List).
+
+-spec add(plist(), string()) -> {ok, plist()} | {error, file:posix()}.
+add(Plist = #machi_plist{list=List0, fd=Fd}, Name) ->
+    case find(Plist, Name) of
+        true ->
+            {ok, Plist};
+        false ->
+            List = lists:append(List0, [Name]),
+            case file:pwrite(Fd, 0, term_to_binary(List)) of
+                ok ->
+                    {ok, Plist#machi_plist{list=List}};
+                Error ->
+                    Error
+            end
+    end.
+
+-ifdef(TEST).
+-spec all(plist()) -> [file:filename()].
+all(#machi_plist{list=List}) ->
+    List.
+-endif.

--- a/src/machi_plist.erl
+++ b/src/machi_plist.erl
@@ -9,14 +9,14 @@
 -endif.
 
 -record(machi_plist,
-        {filename :: string(),
-         fd :: file:descriptor(),
-        list}).
+        {filename :: file:filename_all(),
+         fd :: file:io_device(),
+         list = [] :: list(string)}).
 
 -type plist() :: #machi_plist{}.
 -export_type([plist/0]).
 
--spec open(filename:filename(), proplists:proplist()) ->
+-spec open(file:filename_all(), proplists:proplist()) ->
                   {ok, plist()} | {error, file:posix()}.
 open(Filename, _Opt) ->
     List = case file:read_file(Filename) of

--- a/src/machi_proxy_flu1_client.erl
+++ b/src/machi_proxy_flu1_client.erl
@@ -79,6 +79,7 @@
 
          %% Internal API
          write_chunk/5, write_chunk/6,
+         trim_chunk/5, trim_chunk/6,
 
          %% Helpers
          stop_proxies/1, start_proxies/1
@@ -310,6 +311,18 @@ write_chunk(PidSpec, EpochID, File, Offset, Chunk, Timeout) ->
             Else
     end.
 
+
+trim_chunk(PidSpec, EpochID, File, Offset, Size) ->
+    trim_chunk(PidSpec, EpochID, File, Offset, Size, infinity).
+
+%% @doc Write a chunk (binary- or iolist-style) of data to a file
+%% with `Prefix' at `Offset'.
+
+trim_chunk(PidSpec, EpochID, File, Offset, Chunk, Timeout) ->
+    gen_server:call(PidSpec,
+                    {req, {trim_chunk, EpochID, File, Offset, Chunk}},
+                    Timeout).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 init([I]) ->
@@ -383,6 +396,9 @@ make_req_fun({read_chunk, EpochID, File, Offset, Size, Opts},
 make_req_fun({write_chunk, EpochID, File, Offset, Chunk},
              #state{sock=Sock,i=#p_srvr{proto_mod=Mod}}) ->
     fun() -> Mod:write_chunk(Sock, EpochID, File, Offset, Chunk) end;
+make_req_fun({trim_chunk, EpochID, File, Offset, Size},
+             #state{sock=Sock,i=#p_srvr{proto_mod=Mod}}) ->
+    fun() -> Mod:trim_chunk(Sock, EpochID, File, Offset, Size) end;
 make_req_fun({checksum_list, EpochID, File},
              #state{sock=Sock,i=#p_srvr{proto_mod=Mod}}) ->
     fun() -> Mod:checksum_list(Sock, EpochID, File) end;

--- a/test/machi_csum_table_test.erl
+++ b/test/machi_csum_table_test.erl
@@ -76,13 +76,14 @@ smoke3_test() ->
          {?LINE, trim, {0, 1024, <<>>}, undefined, undefined}
         ],
     [ begin
-          %% ?debugVal({Line, Chunk}),
+          %% ?debugVal({_Line, Chunk}),
           {Offset, Size, Csum} = Chunk,
           ?assertEqual(LeftN0,
                        machi_csum_table:find_leftneighbor(MC, Offset)),
           ?assertEqual(RightN0,
                        machi_csum_table:find_rightneighbor(MC, Offset+Size)),
           LeftN = case LeftN0 of
+                      {OffsL, SizeL, trimmed} -> {OffsL, SizeL, trimmed};
                       {OffsL, SizeL, _} -> {OffsL, SizeL, <<"boom">>};
                       OtherL -> OtherL
                   end,

--- a/test/machi_file_proxy_eqc.erl
+++ b/test/machi_file_proxy_eqc.erl
@@ -170,7 +170,7 @@ start_command(S) ->
 start(_S) ->
     {_, _, MS} = os:timestamp(),
     File = test_server:temp_name("eqc_data") ++ "." ++ integer_to_list(MS),
-    {ok, Pid} = machi_file_proxy:start_link(File, ?TESTDIR),
+    {ok, Pid} = machi_file_proxy:start_link(some_flu, File, ?TESTDIR),
     unlink(Pid),
     Pid.
 

--- a/test/machi_file_proxy_test.erl
+++ b/test/machi_file_proxy_test.erl
@@ -78,7 +78,7 @@ random_binary(Start, End) ->
 
 machi_file_proxy_test_() ->
     clean_up_data_dir(?TESTDIR),
-    {ok, Pid} = machi_file_proxy:start_link("test", ?TESTDIR),
+    {ok, Pid} = machi_file_proxy:start_link(fluname, "test", ?TESTDIR),
     [
      ?_assertEqual({error, bad_arg}, machi_file_proxy:read(Pid, -1, -1)),
      ?_assertEqual({error, bad_arg}, machi_file_proxy:write(Pid, -1, <<"yo">>)),
@@ -100,7 +100,7 @@ machi_file_proxy_test_() ->
 
 multiple_chunks_read_test_() ->
     clean_up_data_dir(?TESTDIR),
-    {ok, Pid} = machi_file_proxy:start_link("test", ?TESTDIR),
+    {ok, Pid} = machi_file_proxy:start_link(fluname, "test", ?TESTDIR),
     [
      ?_assertMatch({ok, "test", _}, machi_file_proxy:append(Pid, random_binary(0, 1024))),
      ?_assertEqual(ok, machi_file_proxy:write(Pid, 10000, <<"fail">>)),

--- a/test/machi_plist_test.erl
+++ b/test/machi_plist_test.erl
@@ -1,0 +1,17 @@
+-module(machi_plist_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+open_close_test() ->
+    FileName = "bark-bark-one",
+    file:delete(FileName),
+    {ok, PList0} = machi_plist:open(FileName, []),
+    {ok, PList1} = machi_plist:add(PList0, "boomar"),
+    ?assertEqual(["boomar"], machi_plist:all(PList1)),
+    ok = machi_plist:close(PList1),
+
+    {ok, PList2} = machi_plist:open(FileName, []),
+    ?assertEqual(["boomar"], machi_plist:all(PList2)),
+    ok = machi_plist:close(PList2),
+    file:delete(FileName),
+    ok.


### PR DESCRIPTION
- maybe_gc/2 is triggered at machi_file_proxy, when chunk is deleted
  and the file is larger than `max_file_size`
- A file is deleted if all chunks except 1024 bytes header are trimmed
- If a file is going to be deleted, file_proxy notifies metadata_mgr
  to remember the filename persistently, whose filename is
  `known_files_<FluName>`
- Such trimmed filenames are stored in a machi_plist file per flu
- machi_file_proxy could not be started if the filename is in the
  manager's list. Consequently, any write, read and trim operations
  cannot happen against deleted file.
- After the file was trimmed, any read request to the file returns
  `{error, trimmed}`
- Disclaimer: no tests written yet and machi_plist does not support
  any recovery from partial writes.
- Add some thoughts as comments for repairing trims.
- State diagram of every byte is as follows:

```
state\action| write/append   | read_chunk       | trim_chunk
------------+----------------+------------------+---------------
 unwritten  |  -> written    | fail (+repair)   | -> trimmed
 written    | noop or repair | return content   | -> trimmed
 trimmed    |  fail          | fail             | noop
```

This pull request is supposed to cover all thoughts or fix to the issues mentioned in #14.
