### PR TITLE
Add missing test cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ifeq ($(REBAR),)
 REBAR = $(BASE_DIR)/rebar
 endif
 OVERLAY_VARS    ?=
+EUNIT_OPTS       = -v
 
 .PHONY: rel deps package pkgclean edoc
 

--- a/src/machi_cr_client.erl
+++ b/src/machi_cr_client.erl
@@ -265,7 +265,8 @@ init([P_srvr_list, Opts]) ->
 
 handle_call({req, Req}, From, S) ->
     handle_call2(Req, From, update_proj(S));
-handle_call(quit, _From, S) ->
+handle_call(quit, _From, #state{members_dict=MembersDict}=S) ->
+    ?FLU_PC:stop_proxies(MembersDict),
     {stop, normal, ok, S};
 handle_call(_Request, _From, S) ->
     Reply = whaaaaaaaaaaaaaaaaaaaa,

--- a/tools.mk
+++ b/tools.mk
@@ -27,6 +27,7 @@
 REBAR ?= ./rebar
 REVISION ?= $(shell git rev-parse --short HEAD)
 PROJECT ?= $(shell basename `find src -name "*.app.src"` .app.src)
+EUNIT_OPTS ?=
 
 .PHONY: compile-no-deps test docs xref dialyzer-run dialyzer-quick dialyzer \
 		cleanplt upload-docs
@@ -35,7 +36,7 @@ compile-no-deps:
 	${REBAR} compile skip_deps=true
 
 test: compile
-	${REBAR} eunit skip_deps=true
+	${REBAR} ${EUNIT_OPTS} eunit skip_deps=true
 
 upload-docs: docs
 	@if [ -z "${BUCKET}" -o -z "${PROJECT}" -o -z "${REVISION}" ]; then \


### PR DESCRIPTION
Add missing cleanup codes for AP-mode repair eqc. Without it, it made other test cases fail (depending on execution order.) The cleanup includes process termination in `#state` of the test, which mitigates process leak memtioned at [1] but does not solve completely.

Also it adds `-v` flag to `rebar eunit` command

[1] https://github.com/basho/machi/issues/37#issuecomment-152521760
